### PR TITLE
Fix usage of token

### DIFF
--- a/lib/web-service.js
+++ b/lib/web-service.js
@@ -61,7 +61,7 @@ const tokenFromConfigObject = (githubTokenConfig) => {
     }
   }
 
-  return token;
+  return token?.replace(/^Bearer +/u, '');
 }
 
 /**
@@ -90,7 +90,7 @@ const gotGithubJsonOptions = (maxAttempts, name, githubTokenConfig = {}) => {
   // eslint-disable-next-line security/detect-possible-timing-attacks
   if (token !== undefined) {
     gotOptions.headers = {
-      Authorization: `${token}`
+      Authorization: `Bearer ${token}`
     };
   }
 
@@ -128,7 +128,7 @@ const gotGithubLicenseFileOptions = (maxAttempts, url, githubTokenConfig = {}) =
   // eslint-disable-next-line security/detect-possible-timing-attacks
   if (token !== undefined) {
     gotOptions.headers = {
-      Authorization: `${token}`
+      Authorization: `Bearer ${token}`
     };
   }
 


### PR DESCRIPTION
`GITHUB_TOKEN` typically doesn't have "Bearer" prefix, and if it is not prepended, the token is not really used.